### PR TITLE
Proposal for how to implement the docs reorg proposal

### DIFF
--- a/docs/index/create-daml-apps/developer-tools/index.rst
+++ b/docs/index/create-daml-apps/developer-tools/index.rst
@@ -1,0 +1,18 @@
+.. Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+Developer Tools
+###############
+
+.. toctree::
+   :titlesonly:
+
+   Daml Assistant </tools/assistant>
+   Experiment: Daml REPL </daml-repl/index>
+   Write: Daml Studio </daml/daml-studio>
+   Test: Daml Sandbox </tools/sandbox>
+   Visualize: Daml Navigator </tools/navigator/index>
+   Measure: Daml Profiler </tools/profiler>
+
+..
+   Operate: Canton Shell (MISSING)

--- a/docs/index/create-daml-apps/off-ledger/daml-off-ledger/index.rst
+++ b/docs/index/create-daml-apps/off-ledger/daml-off-ledger/index.rst
@@ -1,0 +1,17 @@
+.. Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+Daml Off-Ledger Automation
+##########################
+
+.. toctree::
+   :titlesonly:
+   :caption: Write Off-Ledger Automation using Daml
+
+   React to Off-Ledger Events: Daml Script </daml-script/index>
+   React to On-Ledger Events: Daml Triggers </triggers/index>
+
+..
+   - remove toc in /daml-script/index
+   - add /tools/trigger-service/index to toc of /triggers/index
+   - remove /triggers/api/index from toc of /triggers/index

--- a/docs/index/create-daml-apps/off-ledger/errors/index.rst
+++ b/docs/index/create-daml-apps/off-ledger/errors/index.rst
@@ -1,0 +1,11 @@
+.. Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+Errors
+######
+
+.. toctree::
+   :titlesonly:
+
+   Error Codes </app-dev/grpc/error-codes>
+   Command Deduplication </app-dev/command-deduplication>

--- a/docs/index/create-daml-apps/off-ledger/index.rst
+++ b/docs/index/create-daml-apps/off-ledger/index.rst
@@ -1,0 +1,21 @@
+.. Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+Integrate Daml with Off-Ledger Services
+#######################################
+
+.. toctree::
+   :titlesonly:
+
+   Introduction </building-applications>
+   Architectural Patterns </app-dev/app-arch>
+   Access Active Contracts with the HTTP JSON API Service <json-api/index>
+   Write Off-Ledger Automation Using Daml <daml-off-ledger/index>
+   Handle Errors <errors/index>
+   Authorization </app-dev/authorization>
+..
+     Design Patterns (MISSING)
+     Build Integrations with the Ledger API (MISSING)
+
+..
+   - Add /tools/auth-middleware/index to toc of /app-dev/authorization

--- a/docs/index/create-daml-apps/off-ledger/json-api/index.rst
+++ b/docs/index/create-daml-apps/off-ledger/json-api/index.rst
@@ -1,0 +1,17 @@
+.. Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+JSON API
+########
+
+.. toctree::
+   :titlesonly:
+
+   Overview </json-api/index>
+   Daml-LF JSON Encoding </json-api/lf-value-specification>
+   Query Language </json-api/search-query-language>
+   Javascript Client Libraries </app-dev/bindings-ts/index>
+
+..
+   - remove toc in /json-api/index
+   - only keep app-dev/bindings-ts/daml2js in toc of app-dev/bindings-ts/index

--- a/docs/index/create-daml-apps/standard-library/index.rst
+++ b/docs/index/create-daml-apps/standard-library/index.rst
@@ -1,0 +1,15 @@
+.. Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+Daml Standard Library
+#####################
+
+.. toctree::
+   :titlesonly:
+   :maxdepth: 2
+
+   Introduction </daml/intro/11_StdLib>
+   Testing </daml/intro/12_Testing>
+   Good Design Patterns </daml/patterns>
+..
+   Next Steps (MISSING)

--- a/docs/index/deploy-daml/download/index.rst
+++ b/docs/index/deploy-daml/download/index.rst
@@ -1,0 +1,13 @@
+.. Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+Download the Components
+#######################
+
+.. toctree::
+   :titlesonly:
+
+   Daml Enterprise </canton/usermanual/installation>
+..
+   Identity and Access Management Integration (MISSING)
+   Node and Storage Capacity Sizing Principles (MISSING)

--- a/docs/index/deploy-daml/intro/components/index.rst
+++ b/docs/index/deploy-daml/intro/components/index.rst
@@ -1,0 +1,14 @@
+.. Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+Intro
+#####
+
+.. toctree::
+   :titlesonly:
+
+   Introducing Canton </canton/about>
+   Domain Entities </canton/architecture/overview>
+
+..
+   Ledger API (MISSING)

--- a/docs/index/deploy-daml/intro/index.rst
+++ b/docs/index/deploy-daml/intro/index.rst
@@ -1,0 +1,20 @@
+.. Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+Intro
+#####
+
+.. toctree::
+   :titlesonly:
+
+   Components of a Daml Ledger <components/index>
+   Canton 101 </canton/architecture/overview>
+   Canton Demos 1 merge 1-4 </canton/tutorials/demo>
+   Canton Demos 2 </canton/tutorials/getting_started>
+   Canton Demos 3 </canton/tutorials/use_daml_sdk>
+   Canton Demos 4 </canton/tutorials/composability>
+   Compatibility Matrix and Supported Dependencies </canton/usermanual/versioning>
+   Choosing open-source or enterprise edition </canton/usermanual/downloading>
+..
+   High Availability Deployment 1 only google docs
+   Additional Components

--- a/docs/index/deploy-daml/plan-a-deployment/index.rst
+++ b/docs/index/deploy-daml/plan-a-deployment/index.rst
@@ -1,0 +1,13 @@
+.. Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+Plan a Deployment
+#################
+
+.. toctree::
+   :titlesonly:
+
+   Selecting a Sequencer Back End </canton/usermanual/installation>
+..
+   Identity and Access Management Integration (MISSING)
+   Node and Storage Capacity Sizing Principles (MISSING)

--- a/docs/index/index_html.rst
+++ b/docs/index/index_html.rst
@@ -15,55 +15,87 @@ Daml Documentation
    :titlesonly:
    :maxdepth: 2
    :hidden:
-   :caption: Getting started
+   :caption: Home
+..
+   Intro to Multi-Party Apps (MISSING)
+   Intro to Daml (MISSING)
+   Basic Concepts (MISSING)
+   High-Level Architecture (MISSING)
 
-   getting-started/installation
-   Building Your App <getting-started/index>
-   getting-started/app-architecture
-   getting-started/first-feature
-   getting-started/testing
+.. toctree::
+   :titlesonly:
+   :maxdepth: 0
+   :includehidden:
+   :caption: Set Up Your Developer Environment
+
+   Installation </getting-started/installation>
+   System Requirements </ops/requirements>
+   Set JAVA_HOME and PATH Variables </getting-started/path-variables>
+   Manual installation </getting-started/manual-download>
+
+..
+   remove toc in getting-started/installation
 
 .. toctree::
    :titlesonly:
    :maxdepth: 2
    :hidden:
-   :caption: Application development
+   :caption: Tutorial: Write Your first Daml app
 
-   Writing Daml <writing-daml>
-   Building Applications <building-applications>
-   Deploying to Daml Ledgers <deploy/generic_ledger>
-   Operating Daml <operating-daml>
-   Developer Tools <tools>
+   Getting Started </getting-started/index>
+   App Architecture </getting-started/app-architecture>
+   Your First Feature </getting-started/first-feature>
+   Test Your App </getting-started/testing>
+..
+   Next Steps (MISSING)
+
+.. toctree::
+   :titlesonly:
+   :maxdepth: 2
+   :hidden:
+   :caption: Create Daml Apps
+
+   Daml Standard Library </index/create-daml-apps/standard-library/index>
+   Integrate Daml with Off-Ledger Services </index/create-daml-apps/off-ledger/index>
+   Developer Tools </index/create-daml-apps/developer-tools/index>
 
 
 .. toctree::
+   :titlesonly:
+   :hidden:
+   :caption: Deploy Daml
+
+   Intro </index/deploy-daml/intro/index>
+   Plan a Deployment </index/deploy-daml/plan-a-deployment/index>
+   Download the Components </index/deploy-daml/download/index>
+..
+   .. toctree::
    :titlesonly:
    :maxdepth: 2
    :hidden:
    :caption: Platform operations
-
    Introduction <canton/about>
    Tutorials <canton/tutorials/tutorials>
    User Manual <canton/usermanual/usermanual>
    Architecture-In-Depth <canton/architecture/architecture>
 
-.. toctree::
+..
+   .. toctree::
    :titlesonly:
    :maxdepth: 2
    :hidden:
    :caption: Help
-
    daml/troubleshooting
    canton/usermanual/error_codes
    support/support
    support/compatibility
 
-.. toctree::
+..
+   .. toctree::
    :titlesonly:
    :maxdepth: 2
    :hidden:
    :caption: Reference
-
    Cheat Sheet <https://docs.daml.com/cheat-sheet>
    concepts/glossary
    Examples <https://daml.com/examples>
@@ -75,12 +107,12 @@ Daml Documentation
    support/overview
    support/releases
 
-.. toctree::
+..
+   .. toctree::
    :titlesonly:
    :maxdepth: 2
    :hidden:
    :caption: Early access
-
    tools/export/index
    tools/visual
    concepts/interoperability

--- a/docs/index/index_pdf.rst
+++ b/docs/index/index_pdf.rst
@@ -11,11 +11,11 @@ Getting started
    :titlesonly:
    :maxdepth: 2
 
-   getting-started/installation
-   Building Your App <getting-started/index>
-   getting-started/app-architecture
-   getting-started/first-feature
-   getting-started/testing
+   /getting-started/installation
+   Building Your App </getting-started/index>
+   /getting-started/app-architecture
+   /getting-started/first-feature
+   /getting-started/testing
 
 Daml Guide
 ----------
@@ -24,11 +24,11 @@ Daml Guide
    :titlesonly:
    :maxdepth: 2
 
-   Writing Daml <writing-daml>
-   Building Applications <building-applications>
-   Deploying to Daml Ledgers <deploy/generic_ledger>
-   Operating Daml <operating-daml>
-   Developer Tools <tools>
+   Writing Daml </writing-daml>
+   Building Applications </building-applications>
+   Deploying to Daml Ledgers </deploy/generic_ledger>
+   Operating Daml </operating-daml>
+   Developer Tools </tools>
 
 Canton Guide
 ------------
@@ -37,10 +37,10 @@ Canton Guide
    :titlesonly:
    :maxdepth: 2
 
-   Introduction <canton/about>
-   Tutorials <canton/tutorials/tutorials>
-   User Manual <canton/usermanual/usermanual>
-   Architecture-In-Depth <canton/architecture/architecture>
+   Introduction </canton/about>
+   Tutorials </canton/tutorials/tutorials>
+   User Manual </canton/usermanual/usermanual>
+   Architecture-In-Depth </canton/architecture/architecture>
 
 Help
 ----
@@ -49,10 +49,10 @@ Help
    :titlesonly:
    :maxdepth: 2
 
-   daml/troubleshooting
-   canton/usermanual/error_codes
-   support/support
-   support/compatibility
+   /daml/troubleshooting
+   /canton/usermanual/error_codes
+   /support/support
+   /support/compatibility
 
 Reference
 ---------
@@ -62,15 +62,15 @@ Reference
    :maxdepth: 2
 
    Cheat Sheet <https://docs.daml.com/cheat-sheet>
-   concepts/glossary
+   /concepts/glossary
    Examples <https://daml.com/examples>
-   concepts/ledger-model/index
-   concepts/identity-and-package-management
-   concepts/time
-   concepts/local-ledger
-   concepts/test-evidence
-   support/overview
-   support/releases
+   /concepts/ledger-model/index
+   /concepts/identity-and-package-management
+   /concepts/time
+   /concepts/local-ledger
+   /concepts/test-evidence
+   /support/overview
+   /support/releases
 
 Early Access
 ------------
@@ -79,9 +79,9 @@ Early Access
    :titlesonly:
    :maxdepth: 2
 
-   tools/export/index
-   tools/visual
-   concepts/interoperability
-   tools/non-repudiation
-   ops/connect/helm
-   ops/connect/auth0
+   /tools/export/index
+   /tools/visual
+   /concepts/interoperability
+   /tools/non-repudiation
+   /ops/connect/helm
+   /ops/connect/auth0

--- a/docs/live-preview.sh
+++ b/docs/live-preview.sh
@@ -25,7 +25,8 @@ mkdir -p $BUILD_DIR/gen
 DATE=$(date +"%Y-%m-%d")
 echo { \"$DATE\" : \"$DATE\" } >  $BUILD_DIR/gen/versions.json
 
-ln -s $PWD/index/index_html.rst $BUILD_DIR/source/source/index.rst
+ln -sf $PWD/index/index_html.rst $BUILD_DIR/source/source/index.rst
+ln -sf $PWD/index $BUILD_DIR/source/source/index
 
 pipenv install
 pipenv run sphinx-autobuild -c $BUILD_DIR/source/configs/html $BUILD_DIR/source/source $BUILD_DIR/gen


### PR DESCRIPTION
The changes in this PR are based on the original [docs reorg document](https://docs.google.com/document/d/1ygopnOf9WtqsQQN1yW3yESfddhPbmSityJMClZ-qYFg/edit#heading=h.8xjj843v43ys).

# Understanding what changed compared to the previous setup

## Live Preview
The live preview script [creates symlinks](https://github.com/gerolf-da/docs.daml.com/pull/1/files#diff-915ebb6fd6d4b1528dabd2c2dcfd7c28c0a9a237498f92d37259e3aa6fce6da0R28-R29) for the `index` folder and the `index_html.rst` into the build directory.
This means that within the `.rst` files in this repository, all canton content can be linked to with `/canton`, all SDK content with the respective root level folder, e.g. `/getting-started`, and all custom index files with `/index`.

## Structure
The staring point is `index_html.rst`. This is where the main structure / top-level menu items are contained.

### Single level of content
When the doc structure asks for only one level of content, like the [Set Up Your Environment](https://docs.google.com/document/d/1ygopnOf9WtqsQQN1yW3yESfddhPbmSityJMClZ-qYFg/edit#heading=h.vwl67q7k83ji) section, then the sphinx documents from either Canton or SDK can be linked directly into index_html.rst. See [index_html.rst#25-34](https://github.com/gerolf-da/docs.daml.com/pull/1/files#diff-52fbead829e41b82eefb7a8cc30551db4686e2265fe77915fd91282e0de9ed8cR25-R34).

### Multiple levels of content
For more than one level of content, like [Create Daml Apps](https://docs.google.com/document/d/1ygopnOf9WtqsQQN1yW3yESfddhPbmSityJMClZ-qYFg/edit#heading=h.cz4hx37kmczt), the structure is modeled within this repository as a folder structure containing `index.rst` files.
So, for the target structure
```
| Create Daml Apps
|--- Developer Tools
|   |--- Introduction
|   |--- Basic Contracts
|   |--- ...
|--- Integrate Daml with Off-Ledger Services
|   |-- Introduction
|   |--- Access Active Contracts with the HTTP JSON API Service
|   |--- ...
```
the following folder structure is used:
![image](https://user-images.githubusercontent.com/29121423/181801102-b4f65ba9-0475-4053-bba7-826f4be0d0d9.png)
The top-level menu `Create Daml Apps` in `index_html.rst` refers to the `index.rst` files in the sub-folders (e.g. for linking to [developer tools](https://github.com/gerolf-da/docs.daml.com/pull/1/files#diff-52fbead829e41b82eefb7a8cc30551db4686e2265fe77915fd91282e0de9ed8cR60)), which in turn contain a table of content that points to the already existing pages from the canton or SDK docs (see [`/index/create-daml-apps/developer-tools/index`](https://github.com/gerolf-da/docs.daml.com/pull/1/files#diff-ac7beb4bef893ad1232bc22080c14764c9a19df276ff477c96ca816dff4cebe4).

## Required Changes in the Canton or SDK docs
Because of how Sphinx renders the menu for the current document, documents should only be linked to from a single `toctree` directive. In case a document that is covered by this example/PoC is already contained in such a `toctree` directive, I left a comment in the corresponding `index.rst` file in this repository that it needs to be removed in the original original `toctree`. See [docs/index/create-daml-apps/off-ledger/json-api/index.rst](https://github.com/gerolf-da/docs.daml.com/pull/1/files#diff-7a192e8243d9863e4862fb4dac5e0c160cd4050b66cce630954e581610cb267cR16) as example.